### PR TITLE
Fix an incorrect name in the Helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ More information about these configurations can be found in the [Deploy Sematic 
 | `service.type`                                            | K8S service type for Sematic server service                   | `ClusterIP`                             |
 | `service.port`                                            | K8S service port for Sematic server service                   | `80`                                    |
 | `ingress.create`                                          | Enables creation of K8S ingress for Sematic server            | `false`                                 |
-| `ingress.dashboard_url`                                   | Public dashboard URL to K8S ingress for Sematic server        | Not set                                 |
+| `ingress.sematic_dashboard_url`                           | Public dashboard URL to K8S ingress for Sematic server        | Not set                                 |
 | `ingress.class_name`                                      | K8S ingress class name for Sematic server                     | `""`                                    |
 | `ingress.annotations`                                     | K8S ingress annotations for Sematic server                    | `{}`                                    |
 | `ingress.hosts`                                           | K8S ingress hosts YAML spec for Sematic server                | See default values.yml                  |


### PR DESCRIPTION
This reflects the fix in https://github.com/sematic-ai/sematic/pull/547.